### PR TITLE
Clear auto suggestions when bracketed paste is run

### DIFF
--- a/etc/zsh/zshrc.dist
+++ b/etc/zsh/zshrc.dist
@@ -35,9 +35,22 @@ setopt promptsubst
 setopt printexitvalue
 
 # https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/safe-paste/safe-paste.plugin.zsh
+# https://github.com/zsh-users/zsh-autosuggestions/issues/511#issuecomment-962671126
 set zle_bracketed_paste  # Explicitly restore this zsh default
 autoload -Uz bracketed-paste-magic
 zle -N bracketed-paste bracketed-paste-magic
+autoload -U url-quote-magic bracketed-paste-magic
+zle -N self-insert url-quote-magic
+
+pasteinit() {
+  OLD_SELF_INSERT=${${(s.:.)widgets[self-insert]}[2,3]}
+  zle -N self-insert url-quote-magic
+}
+pastefinish() {
+  zle -N self-insert $OLD_SELF_INSERT
+}
+zstyle :bracketed-paste-magic paste-init pasteinit
+zstyle :bracketed-paste-magic paste-finish pastefinish
 
 ## base for any shell
 source ${zsh_custom_dir}/shrc
@@ -61,6 +74,8 @@ if test "$color_prompt" = "yes"; then
   ## Enable auto-suggestions based on the history
   if test -f /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh; then
     ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=30
+    typeset -a ZSH_AUTOSUGGEST_CLEAR_WIDGETS
+    ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(bracketed-paste)
     source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
   fi
   ## Highlight commands as you type
@@ -90,6 +105,3 @@ fi
 if test -f /etc/zsh_command_not_found; then
   source /etc/zsh_command_not_found
 fi
-
-
-


### PR DESCRIPTION
This pull request changes...

## Changes

Clear auto suggestions when bracketed paste is run

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it

Fixes #

https://forums.whonix.org/t/why-does-xfce-terminal-paste-commands-1-character-at-a-time/20227