### PR TITLE
Convert livecheck tooltips to dialog

### DIFF
--- a/usr/share/livecheck/livecheck.sh
+++ b/usr/share/livecheck/livecheck.sh
@@ -81,7 +81,7 @@ test -f "${icon_grub_live_with_read_only}" || missing_icon=true
 if [ "$missing_icon" = "true" ]; then
    bug_message="
 
-(Minor bug: Missing icons.)"
+(Minor bug: Missing icons)"
 else
    bug_message=""
 fi
@@ -116,7 +116,7 @@ elif echo "${proc_cmdline_output}" | grep --no-messages --quiet 'root=live' ; th
    status_word="ISO"
    maybe_iso_live_message="
 
-This does not matter if you are only using this ISO to install to the hard drive. In that case, this message can be safely ignored."
+This message can be safely ignored if only using this ISO to install to the hard drive."
 fi
 
 if echo "$lsblk_output" | grep --quiet "0" ; then
@@ -132,7 +132,7 @@ if echo "$lsblk_output" | grep --quiet "0" ; then
       fi
       ## Show "Live" or "ISO" next to info symbol in systray.
       echo "<txt>$status_word</txt>"
-      echo "<tool>Live Mode Active (${live_mode_environment}): Your system is currently running in live mode, ensuring no changes are made to the disk. For added security, consider setting your disk to read-only mode, if possible. See: ${homepage}/wiki/Live_Mode or click on the icon for more information.${maybe_iso_live_message}${bug_message}</tool>"
+      echo "<tool>Live Mode Active (${live_mode_environment}): No changes will be made to disk. For added security and if possible, consider setting your disk to read-only mode. See: ${homepage}/wiki/Live_Mode or click on the icon for more information.${maybe_iso_live_message}${bug_message}</tool>"
       echo "<click>x-www-browser ${homepage}/wiki/read-only</click>"
       echo "<txtclick>x-www-browser ${homepage}/wiki/read-only</txtclick>"
    else
@@ -140,17 +140,17 @@ if echo "$lsblk_output" | grep --quiet "0" ; then
       echo "<img>${icon_persistent_mode}</img>"
       ## Do not show "Persistent" next to info symbol in systray.
       #echo "<txt>Persistent</txt>"
-      echo "<tool>Persistent Mode Active: Your system is currently in persistent mode, and all changes to the disk will be preserved after a reboot. For using live mode, which enables temporary sessions where changes are not saved to the disk, see: ${homepage}/wiki/Live_Mode or click on the icon for more information.${bug_message}</tool>"
+      echo "<tool>Persistent Mode Active: All changes to the disk will be preserved after a reboot. If, instead, you would like to be in live mode, which enables temporary sessions where changes are not saved to the disk, see: ${homepage}/wiki/Live_Mode or click on the icon for more information.${bug_message}</tool>"
       echo "<click>x-www-browser ${homepage}/wiki/Live_Mode</click>"
       echo "<txtclick>x-www-browser ${homepage}/wiki/Live_Mode<txtclick>"
    fi
 else
-   true "INFO: No '0' is found. Therefore only '1' found. Conclusion: read-only."
+   true "INFO: No '0' found. Therefore only '1' found. Conclusion: read-only."
 
    echo "<img>${icon_grub_live_with_read_only}</img>"
    ## Show "read-only" next to info symbol in systray.
    echo "<txt>read-only</txt>"
-   echo "<tool>Live Mode Active (${live_mode_environment}): All changes to the disk will be gone after a reboot. See: ${homepage}/wiki/Live_Mode or click on the icon for more information.${bug_message}</tool>"
+   echo "<tool>Live Mode Active (${live_mode_environment}): No changes will be made to disk. See: ${homepage}/wiki/Live_Mode or click on the icon for more information.${bug_message}</tool>"
    echo "<click>x-www-browser ${homepage}/wiki/Live_Mode</click>"
    echo "<txtclick>x-www-browser ${homepage}/wiki/Live_Mode</txtclick>"
 fi

--- a/usr/share/livecheck/livecheck.sh
+++ b/usr/share/livecheck/livecheck.sh
@@ -66,6 +66,8 @@ fi
 missing_icon=""
 icon_dir="/usr/share/icons/gnome-colors-common/32x32"
 
+msg_cmd="/usr/libexec/msgcollector/generic_gui_message"
+
 icon_error="${icon_dir}/status/dialog-error.png"
 icon_persistent_mode="${icon_dir}/status/dialog-information.png"
 icon_grub_live_without_read_only="${icon_dir}/status/user-online.png"
@@ -93,9 +95,12 @@ if ! lsblk_output="$(sudo --non-interactive /bin/lsblk --noheadings --raw --outp
    echo "<img>${icon_error}</img>"
    ## Show "Error" next to info symbol in systray.
    echo "<txt>Error</txt>"
-   echo "<tool>Live Detection Test: Minor issue. Do not panic. Unable to determine if booted into live mode or persistent mode. For assistance and to report this issue, please visit: ${homepage}/wiki/Grub-live#Live_Check_Systray_Issues or click on the icon for more information.${bug_message}</tool>"
-   echo "<click>x-www-browser ${homepage}/wiki/Grub-live#Live_Check_Systray_Issues</click>"
-   echo "<txtclick>x-www-browser ${homepage}/wiki/Grub-live#Live_Check_Systray_Issues</txtclick>"
+   title="Livecheck"
+   link="<a href=\"${homepage}/wiki/Grub-live#Live_Check_Systray_Issues\">${homepage}/wiki/Grub-live#Live_Check_Systray_Issues</a>"
+   msg="Live Detection Test: Minor issue. Do not panic. Unable to determine if booted into live mode or persistent mode. For assistance and to report this issue, please visit: ${link}.${bug_message}"
+   click="${msg_cmd} error '${title}' '${msg}' '' ok"
+   echo "<click>${click}</click>"
+   echo "<txtclick>${click}</txtclick>"
    exit 0
 fi
 ## lsblk exited with exit code 0.
@@ -125,24 +130,33 @@ if echo "$lsblk_output" | grep --quiet "0" ; then
       true "INFO: grub-live or ISO live is enabled."
       if [ "$live_mode_environment" = "grub-live" ]; then
          echo "<img>${icon_grub_live_without_read_only}</img>"
+         msg_type="warning"
       elif [ "$live_mode_environment" = "ISO Live" ]; then
          echo "<img>${icon_iso}</img>"
+         msg_type="warning"
       else
          echo "<img>${icon_error}</img>"
+         msg_type="error"
       fi
       ## Show "Live" or "ISO" next to info symbol in systray.
       echo "<txt>$status_word</txt>"
-      echo "<tool>Live Mode Active (${live_mode_environment}): No changes will be made to disk. For added security and if possible, consider setting your disk to read-only mode. See: ${homepage}/wiki/Live_Mode or click on the icon for more information.${maybe_iso_live_message}${bug_message}</tool>"
-      echo "<click>x-www-browser ${homepage}/wiki/read-only</click>"
-      echo "<txtclick>x-www-browser ${homepage}/wiki/read-only</txtclick>"
+      title="Livecheck"
+      link="<a href=\"${homepage}/wiki/Live_mode\">${homepage}/wiki/Live_Mode</a>"
+      msg="Live Mode Active (${live_mode_environment}): No changes will be made to disk. For added security and if possible, consider <a href=\"${homepage}/wiki/Read-only\">setting your disk to read-only mode</a>. See: ${link}.${maybe_iso_live_message}${bug_message}"
+      click="${msg_cmd} ${msg_type} '${title}' '${msg}' '' ok"
+      echo "<click>${click}</click>"
+      echo "<txtclick>${click}</txtclick>"
    else
       true "INFO: Live mode and/or ISO live is disabled."
       echo "<img>${icon_persistent_mode}</img>"
       ## Do not show "Persistent" next to info symbol in systray.
       #echo "<txt>Persistent</txt>"
-      echo "<tool>Persistent Mode Active: All changes to the disk will be preserved after a reboot. If, instead, you would like to be in live mode, which enables temporary sessions where changes are not saved to the disk, see: ${homepage}/wiki/Live_Mode or click on the icon for more information.${bug_message}</tool>"
-      echo "<click>x-www-browser ${homepage}/wiki/Live_Mode</click>"
-      echo "<txtclick>x-www-browser ${homepage}/wiki/Live_Mode<txtclick>"
+      title="Livecheck"
+      link="<a href=\"${homepage}/wiki/Live_Mode\">${homepage}/wiki/Live_mode</a>"
+      msg="Persistent Mode Active: All changes to the disk will be preserved after a reboot. If, instead, you would like to be in live mode, which enables temporary sessions where changes are not saved to the disk. See: ${link}.${bug_message}"
+      click="${msg_cmd} info '${title}' '${msg}' '' ok"
+      echo "<click>${click}</click>"
+      echo "<txtclick>${click}</txtclick>"
    fi
 else
    true "INFO: No '0' found. Therefore only '1' found. Conclusion: read-only."
@@ -150,7 +164,10 @@ else
    echo "<img>${icon_grub_live_with_read_only}</img>"
    ## Show "read-only" next to info symbol in systray.
    echo "<txt>read-only</txt>"
-   echo "<tool>Live Mode Active (${live_mode_environment}): No changes will be made to disk. See: ${homepage}/wiki/Live_Mode or click on the icon for more information.${bug_message}</tool>"
-   echo "<click>x-www-browser ${homepage}/wiki/Live_Mode</click>"
-   echo "<txtclick>x-www-browser ${homepage}/wiki/Live_Mode</txtclick>"
+   title="Livecheck"
+   link="<a href=\"${homepage}/wiki/Live_mode\">${homepage}/wiki/Live_Mode</a>"
+   msg="Live Mode Active (${live_mode_environment}): No changes will be made to disk. See: ${link}.${bug_message}"
+   click="${msg_cmd} warning '${title}' '${msg}' '' ok"
+   echo "<click>${click}</click>"
+   echo "<txtclick>${click}</txtclick>"
 fi


### PR DESCRIPTION
This pull request changes...

## Changes

Convert livecheck tooltips to dialog and better messages.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally: On Qubes and manually running options, not on full GUI
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
